### PR TITLE
fix classpath for PuppetQuery command

### DIFF
--- a/build/build.iml
+++ b/build/build.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/puppet-plugin-agent/src/main/kotlin/org/jetbrains/puppet/agent/PuppetQueryFactory.kt
+++ b/puppet-plugin-agent/src/main/kotlin/org/jetbrains/puppet/agent/PuppetQueryFactory.kt
@@ -4,6 +4,7 @@ package org.jetbrains.puppet.agent
 import jetbrains.buildServer.agent.AgentBuildRunnerInfo
 import jetbrains.buildServer.agent.BuildAgentConfiguration
 import jetbrains.buildServer.agent.plugins.beans.AgentPluginInfo
+import jetbrains.buildServer.agent.plugins.beans.PluginDescriptor
 import jetbrains.buildServer.agent.runner.BuildServiceAdapter
 import jetbrains.buildServer.agent.runner.CommandLineBuildService
 import jetbrains.buildServer.agent.runner.CommandLineBuildServiceFactory
@@ -11,7 +12,9 @@ import jetbrains.buildServer.agent.runner.ProgramCommandLine
 import org.jetbrains.puppet.common.PUPPET_QUERY_RUNNER_TYPE
 
 
-public class PuppetQueryFactory : CommandLineBuildServiceFactory {
+public class PuppetQueryFactory(pd: PluginDescriptor) : CommandLineBuildServiceFactory {
+    val pluginDescriptor = pd;
+
     override fun getBuildRunnerInfo(): AgentBuildRunnerInfo {
         return object: AgentBuildRunnerInfo {
             override fun canRun(buildConfiguration: BuildAgentConfiguration): Boolean {
@@ -26,7 +29,7 @@ public class PuppetQueryFactory : CommandLineBuildServiceFactory {
     }
 
     override fun createService(): CommandLineBuildService {
-        return PuppetQueryService()
+        return PuppetQueryService(pluginDescriptor)
     }
 }
 

--- a/puppet-plugin-agent/src/main/kotlin/org/jetbrains/puppet/agent/PuppetQueryService.kt
+++ b/puppet-plugin-agent/src/main/kotlin/org/jetbrains/puppet/agent/PuppetQueryService.kt
@@ -3,28 +3,44 @@ package org.jetbrains.puppet.agent
 import jetbrains.buildServer.agent.AgentBuildParameters
 import jetbrains.buildServer.agent.AgentRuntimeProperties
 import jetbrains.buildServer.agent.plugins.beans.AgentPluginInfo
+import jetbrains.buildServer.agent.plugins.beans.PluginDescriptor
 import jetbrains.buildServer.agent.runner.BuildServiceAdapter
 import jetbrains.buildServer.agent.runner.JavaCommandLineBuilder
 import jetbrains.buildServer.agent.runner.JavaRunnerUtil
 import jetbrains.buildServer.agent.runner.ProgramCommandLine
 import jetbrains.buildServer.runner.JavaRunnerConstants
+import java.io.File
 
 
+public class PuppetQueryService(pd: PluginDescriptor) : BuildServiceAdapter() {
+    val pluginDescriptor = pd;
 
-public class PuppetQueryService: BuildServiceAdapter() {
     override fun makeProgramCommandLine(): ProgramCommandLine {
         val clBuilder = JavaCommandLineBuilder()
         clBuilder.setJavaHome(getRunnerParameters().get(JavaRunnerConstants.TARGET_JDK_HOME))
         clBuilder.setBaseDir(getCheckoutDirectory().getAbsolutePath())
         clBuilder.setWorkingDir(getWorkingDirectory().getAbsolutePath())
-        clBuilder.setClassPath("")
+        clBuilder.setClassPath(getClasspath());
         clBuilder.setEnvVariables(getRunnerContext().getBuildParameters().getEnvironmentVariables())
         clBuilder.setJvmArgs(JavaRunnerUtil.extractJvmArgs(getRunnerParameters()))
-        //clBuilder.setMainClass("org.jetbrains.puppet.agent.PuppetQuery")
         clBuilder.setMainClass("org.jetbrains.puppet.agent.PuppetQuery")
 
-
         return clBuilder.build()
+    }
+
+    private fun getClasspath(): String {
+        val classpath = StringBuilder();
+        val pluginRoot = this.pluginDescriptor.getPluginRoot();
+        val pluginLibs = File(pluginRoot, "lib");
+        val separator = File.pathSeparator;
+        val libs = pluginLibs.listFiles();
+        if (libs != null) {
+            for (lib in libs) {
+                classpath.append(lib.getAbsolutePath());
+                classpath.append(separator);
+            }
+        }
+        return classpath.toString();
     }
 
     override fun beforeProcessStarted() {


### PR DESCRIPTION
This change fixes classpath for PuppetQuery command. For simplicity classpath contains all libs of the agent part of the plugin even though probably not all of them are used by PuppetQuery.
